### PR TITLE
Readme: fix .gif not displaying

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A HaxeFlixel library designed to make real-time normal map based lighting easy to include in HaxeFlixel projects
 
-![Demo](https://dl.dropboxusercontent.com/u/1491523/flixelighting/demo.gif)
+![Demo](demo.gif)
 
 ## Features
 


### PR DESCRIPTION
It looks like the .gif was already part of the repo at some point, but was then moved to Dropbox.. and then probably broke because of the Dropbox public folder changes?

![](http://i.imgur.com/mrthkdf.png)

In case you're removed the .gif from the repo for file size reasons - that doesn't really help, it's still part of the commit history / the `.git` directory.